### PR TITLE
refactor config

### DIFF
--- a/src/localpen/config/__tests__/upgrade-config.spec.ts
+++ b/src/localpen/config/__tests__/upgrade-config.spec.ts
@@ -66,7 +66,7 @@ describe('upgradeConfig', () => {
       compiled: '',
       editor: '',
       allowLangChange: true,
-      language: 'html',
+      activeEditor: 'markup',
       markup: {
         language: 'html',
         content: '',

--- a/src/localpen/config/__tests__/validate-config.spec.ts
+++ b/src/localpen/config/__tests__/validate-config.spec.ts
@@ -29,6 +29,7 @@ describe('validateConfig', () => {
       },
       allowLangChange: true,
       language: 'html',
+      activeEditor: 'markup',
       markup: {
         language: 'html',
         content: '',
@@ -61,7 +62,7 @@ describe('validateConfig', () => {
       console: '',
       compiled: '',
       allowLangChange: true,
-      language: 'html',
+      activeEditor: 'markup',
       markup: {
         language: 'html',
         content: '',

--- a/src/localpen/config/default-config.ts
+++ b/src/localpen/config/default-config.ts
@@ -12,7 +12,7 @@ export const defaultConfig: Pen = {
   console: '',
   compiled: '',
   allowLangChange: true,
-  language: undefined,
+  activeEditor: undefined,
   languages: undefined,
   markup: {
     language: 'html',

--- a/src/localpen/config/load-config.ts
+++ b/src/localpen/config/load-config.ts
@@ -1,6 +1,6 @@
 import { importCode } from '../import';
 import { getLanguageByAlias, getLanguageEditorId } from '../languages';
-import { EditorId, Pen } from '../models';
+import { EditorId, Language, Pen } from '../models';
 import { getTemplate } from '../templates';
 import { decodeHTML } from '../utils';
 import { defaultConfig } from './default-config';
@@ -20,9 +20,6 @@ export const loadConfig = async (appConfig: Partial<Pen> = {}) => {
     if (params[key] === 'false') params[key] = false;
   });
 
-  // get template name from query string param
-  const templateName = params.template;
-
   // load config from file
   const configUrl = params.config || './localpen.json';
   const fileConfig = configUrl
@@ -33,122 +30,150 @@ export const loadConfig = async (appConfig: Partial<Pen> = {}) => {
       )
     : {};
 
-  // initialize params config with default keys
+  let config: Pen = {
+    ...defaultConfig,
+    ...fileConfig,
+    ...userConfig,
+  };
+
+  const paramsConfig = loadParamConfig(config, params);
+
+  config = {
+    ...config,
+    ...paramsConfig,
+  };
+
+  const externalContent = await loadExternalContent(config, params);
+
+  const activeEditor =
+    paramsConfig.activeEditor || externalContent.activeEditor || config.activeEditor || 'markup';
+
+  config = {
+    ...config,
+    ...externalContent,
+    activeEditor,
+  };
+
+  return config;
+};
+
+const loadExternalContent = async (config: Pen, params: { [key: string]: string }) => {
+  // load a starter template
+  const templateName = params.template;
+  const templateConfig = templateName ? await getTemplate(templateName, config) : undefined;
+  if (templateConfig) {
+    return templateConfig;
+  }
+
+  // import code from hash: code / github / github gist / url html / ...etc
+  const url = window.location.hash.substring(1);
+  if (url) {
+    return upgradeAndValidate(await importCode(url, params, config));
+  }
+
+  // load content from config contentUrl
+  const editorIds: EditorId[] = ['markup', 'style', 'script'];
+  const editors = await Promise.all(
+    editorIds.map((editorId) => {
+      const contentUrl = config[editorId].contentUrl;
+      if (contentUrl && !config[editorId].content) {
+        return fetch(contentUrl)
+          .then((res) => res.text())
+          .then((content) => ({
+            ...config[editorId],
+            content,
+          }));
+      } else {
+        return Promise.resolve(config[editorId]);
+      }
+    }),
+  );
+  return {
+    markup: editors[0],
+    style: editors[1],
+    script: editors[2],
+  };
+};
+
+const loadParamConfig = (config: Pen, params: { [key: string]: string }) => {
+  // ?js
+  // ?lang=js
+  // ?language=js
+  // ?css&js&md
+  // ?html=hi&scss&ls
+  // ?html=hi&scss=body{}&ts=//hi&lang=scss
+  // ?languages=html,md,css,scss,ts
+
+  // initialize paramsConfig with defaultConfig keys and params values
   let paramsConfig = (Object.keys(defaultConfig) as Array<keyof Omit<Pen, 'version'>>).reduce(
-    (acc, key) => {
-      acc[key] = params[key];
-      return acc;
-    },
+    (acc, key) => ({
+      ...acc,
+      [key]: params[key],
+    }),
     {} as Partial<Pen>,
   );
 
   // populate params config from query string params
 
-  // ?html=hi
-  const languageAliases = ['language', 'lang'];
+  // ?html=hi&scss&ts
   Object.keys(params).forEach((key) => {
     const language = getLanguageByAlias(key);
     if (!language) return;
     const editorId = getLanguageEditorId(language);
-
     if (editorId && !paramsConfig[editorId]) {
-      // >> query param
-      // >> user defined config object
-      // >> config file
-      // >> default config
-      // >> empty string
       const content =
-        typeof params[key] === 'string' && !languageAliases.includes(key)
-          ? decodeHTML(decodeURIComponent(params[key]))
-          : language === userConfig[editorId]?.language
-          ? userConfig[editorId]?.content
-          : language === fileConfig[editorId]?.language
-          ? fileConfig[editorId]?.content
-          : language === defaultConfig[editorId]?.language
-          ? defaultConfig[editorId]?.content
-          : '';
+        typeof params[key] === 'string' ? decodeHTML(decodeURIComponent(params[key])) : '';
       paramsConfig[editorId] = { language, content };
-      paramsConfig.activeEditor = paramsConfig.activeEditor || editorId;
-    }
-  });
-
-  // ?lang=scss
-  (() => {
-    if ('language' in params || 'lang' in params) {
-      const language = getLanguageByAlias(params.language || params.lang);
-      if (!language) return;
-      const editorId = getLanguageEditorId(language);
-      if (!editorId) return;
-
-      if (paramsConfig[editorId]?.language === getLanguageByAlias(language)) {
-        paramsConfig.activeEditor = editorId;
-      } else if (!paramsConfig[editorId]?.content) {
-        paramsConfig[editorId] = { language, content: '' };
+      if (!paramsConfig.activeEditor) {
         paramsConfig.activeEditor = editorId;
       }
     }
-  })();
+  });
+
+  // ?lang=js
+  const lang: any = getLanguageByAlias(params.language || params.lang);
+  const editorId = getLanguageEditorId(lang);
+  if (editorId) {
+    if (paramsConfig[editorId]?.language === lang) {
+      paramsConfig.activeEditor = editorId;
+    } else if (!paramsConfig[editorId]?.content && config[editorId]?.language === lang) {
+      paramsConfig[editorId] = {
+        ...config[editorId],
+      };
+      paramsConfig.activeEditor = editorId;
+    } else if (!config[editorId]?.content) {
+      paramsConfig[editorId] = {
+        language: lang,
+        content: '',
+      };
+      paramsConfig.activeEditor = editorId;
+    }
+  }
+
+  const editorIds: EditorId[] = ['markup', 'style', 'script'];
 
   // ?activeEditor=style
-  if ('activeEditor' in params || 'active' in params) {
-    paramsConfig.activeEditor = params.activeEditor || params.active;
-  }
   // ?active=1  (same as: ?activeEditor=style)
-  const editorIds: EditorId[] = ['markup', 'style', 'script'];
-  if (editorIds[paramsConfig.activeEditor as any]) {
-    paramsConfig.activeEditor = editorIds[paramsConfig.activeEditor as any];
+  const paramsActiveEditor: any = params.activeEditor;
+  const paramsActive: any = params.active;
+  paramsConfig.activeEditor = editorIds.includes(paramsActiveEditor) // ?activeEditor=style
+    ? paramsActiveEditor
+    : paramsActiveEditor in editorIds // ?activeEditor=1
+    ? editorIds[paramsActiveEditor]
+    : editorIds.includes(paramsActive) // ?active=style
+    ? paramsActive
+    : paramsActive in editorIds // ?active=1
+    ? editorIds[paramsActive]
+    : paramsConfig.activeEditor;
+
+  if (typeof params.languages === 'string') {
+    paramsConfig.languages = params.languages
+      .split(',')
+      .map(getLanguageByAlias)
+      .filter(Boolean) as Language[];
   }
 
   // convert params config to a valid config object
   paramsConfig = upgradeAndValidate(paramsConfig);
-
-  let config: Pen = {
-    ...defaultConfig,
-    ...fileConfig,
-    ...userConfig,
-    ...paramsConfig,
-  };
-
-  // if a template is chosen, return its content (avoid loading external content)
-  if (templateName) {
-    const template = await getTemplate(templateName, config);
-    if (template) {
-      return {
-        ...config,
-        ...template,
-      };
-    }
-  }
-
-  // load content from url
-  const contents = await Promise.all(
-    [config.markup, config.style, config.script].map((editor) => {
-      if (editor.contentUrl && !editor.content) {
-        return fetch(editor.contentUrl).then((res) => res.text());
-      } else {
-        return Promise.resolve(editor.content);
-      }
-    }),
-  );
-  config.markup.content = contents[0];
-  config.style.content = contents[1];
-  config.script.content = contents[2];
-
-  // import code from hash code / github / github gist / url html / ...etc
-  const url = window.location.hash.substring(1);
-  if (url) {
-    const importedcode = upgradeAndValidate(await importCode(url, params, config));
-    config = {
-      ...config,
-      ...importedcode,
-    };
-  }
-
-  // if activeEditor is not set, default to 'markup'
-  config = {
-    ...config,
-    ...(config.activeEditor ? { activeEditor: config.activeEditor } : { activeEditor: 'markup' }),
-  };
-
-  return config;
+  return paramsConfig;
 };

--- a/src/localpen/config/upgrade-config.ts
+++ b/src/localpen/config/upgrade-config.ts
@@ -1,3 +1,4 @@
+import { getLanguageEditorId } from '../languages';
 import { Pen } from '../models';
 import { defaultConfig } from './default-config';
 
@@ -25,6 +26,10 @@ const upgradeSteps = [
       }
       if ('editor' in config && typeof config.editor !== 'string') {
         config.editor = '';
+      }
+      if ('language' in config) {
+        config.activeEditor = getLanguageEditorId(config.language);
+        delete config.language;
       }
 
       return {

--- a/src/localpen/config/validate-config.ts
+++ b/src/localpen/config/validate-config.ts
@@ -20,6 +20,7 @@ export const validateConfig = (config: Partial<Pen>): Partial<Pen> => {
   const modes = ['full', 'editor', 'codeblock', 'result'];
   const toolsPaneStatus = ['', 'full', 'closed', 'open', 'none'];
   const editors = ['monaco', 'codemirror', 'prism', ''];
+  const editorIds = ['markup', 'style', 'script'];
 
   const isEditor = (x: any) => {
     if (!x) return false;
@@ -46,7 +47,7 @@ export const validateConfig = (config: Partial<Pen>): Partial<Pen> => {
     ...(includes(toolsPaneStatus, config.console) ? { console: config.console } : {}),
     ...(includes(toolsPaneStatus, config.compiled) ? { compiled: config.compiled } : {}),
     ...(is(config.allowLangChange, 'boolean') ? { allowLangChange: config.allowLangChange } : {}),
-    ...(is(config.language, 'string') ? { language: config.language } : {}),
+    ...(includes(editorIds, config.activeEditor) ? { activeEditor: config.activeEditor } : {}),
     ...(is(config.languages, 'array', 'string') ? { languages: config.languages } : {}),
     ...(isEditor(config.markup) ? { markup: validateEditorProps(config.markup as Editor) } : {}),
     ...(isEditor(config.style) ? { style: validateEditorProps(config.style as Editor) } : {}),

--- a/src/localpen/import/github.ts
+++ b/src/localpen/import/github.ts
@@ -64,7 +64,7 @@ const getContent = async (fileData: FileData): Promise<Partial<Pen>> => {
         language,
         content,
       },
-      language,
+      activeEditor: editorId,
     };
   } catch (error) {
     // eslint-disable-next-line no-console

--- a/src/localpen/import/gitlab.ts
+++ b/src/localpen/import/gitlab.ts
@@ -59,7 +59,7 @@ const getContent = async (fileData: Promise<FileData>): Promise<Partial<Pen>> =>
         language,
         content,
       },
-      language,
+      activeEditor: editorId,
     };
   } catch (error) {
     // eslint-disable-next-line no-console

--- a/src/localpen/models.ts
+++ b/src/localpen/models.ts
@@ -12,7 +12,7 @@ export interface Pen {
   console: ToolsPaneStatus;
   compiled: ToolsPaneStatus;
   allowLangChange: boolean;
-  language: Language | undefined;
+  activeEditor: EditorId | undefined;
   languages: Language[] | undefined;
   markup: Editor;
   style: Editor;
@@ -200,7 +200,7 @@ export interface Template {
   name: string;
   title: string;
   thumbnail: string;
-  language: Language;
+  activeEditor: EditorId;
   markup: Editor;
   style: Editor;
   script: Editor;

--- a/src/localpen/templates/starter/angular-starter.ts
+++ b/src/localpen/templates/starter/angular-starter.ts
@@ -4,7 +4,7 @@ export const angularStarter: Template = {
   name: 'angular',
   title: 'Angular Starter',
   thumbnail: 'assets/templates/angular.svg',
-  language: 'ts',
+  activeEditor: 'script',
   markup: {
     language: 'html',
     content: '<app>Loading...</app>\n',

--- a/src/localpen/templates/starter/assemblyscript-starter.ts
+++ b/src/localpen/templates/starter/assemblyscript-starter.ts
@@ -4,7 +4,7 @@ export const assemblyscriptStarter: Template = {
   name: 'assemblyscript',
   title: 'AssemblyScript Starter',
   thumbnail: 'assets/templates/assemblyscript.svg',
-  language: 'assemblyscript',
+  activeEditor: 'script',
   markup: {
     language: 'html',
     content: `

--- a/src/localpen/templates/starter/blank.ts
+++ b/src/localpen/templates/starter/blank.ts
@@ -4,7 +4,7 @@ export const blank: Template = {
   name: 'blank',
   title: 'Blank Project',
   thumbnail: 'assets/templates/blank.svg',
-  language: 'html',
+  activeEditor: 'markup',
   markup: {
     language: 'html',
     content: '',

--- a/src/localpen/templates/starter/bootstrap-starter.ts
+++ b/src/localpen/templates/starter/bootstrap-starter.ts
@@ -4,7 +4,7 @@ export const bootstrapStarter: Template = {
   name: 'bootstrap',
   title: 'Bootstrap Starter',
   thumbnail: 'assets/templates/bootstrap.svg',
-  language: 'html',
+  activeEditor: 'markup',
   markup: {
     language: 'html',
     content: `

--- a/src/localpen/templates/starter/d3-starter.ts
+++ b/src/localpen/templates/starter/d3-starter.ts
@@ -4,7 +4,7 @@ export const d3Starter: Template = {
   name: 'd3',
   title: 'D3 Starter',
   thumbnail: 'assets/templates/d3.svg',
-  language: 'js',
+  activeEditor: 'script',
   markup: {
     language: 'html',
     content: '<div id="chart">Loading...</div>\n',

--- a/src/localpen/templates/starter/jquery-starter.ts
+++ b/src/localpen/templates/starter/jquery-starter.ts
@@ -4,7 +4,7 @@ export const jqueryStarter: Template = {
   name: 'jquery',
   title: 'jQuery Starter',
   thumbnail: 'assets/templates/jquery.svg',
-  language: 'js',
+  activeEditor: 'script',
   markup: {
     language: 'html',
     content: `

--- a/src/localpen/templates/starter/livescript-starter.ts
+++ b/src/localpen/templates/starter/livescript-starter.ts
@@ -4,7 +4,7 @@ export const livescriptStarter: Template = {
   name: 'livescript',
   title: 'LiveScript Starter',
   thumbnail: 'assets/templates/livescript.svg',
-  language: 'livescript',
+  activeEditor: 'script',
   markup: {
     language: 'html',
     content: `

--- a/src/localpen/templates/starter/lua-starter.ts
+++ b/src/localpen/templates/starter/lua-starter.ts
@@ -4,7 +4,7 @@ export const luaStarter: Template = {
   name: 'lua',
   title: 'Lua Starter',
   thumbnail: 'assets/templates/lua.svg',
-  language: 'lua',
+  activeEditor: 'script',
   markup: {
     language: 'html',
     content: `

--- a/src/localpen/templates/starter/mdx-starter.ts
+++ b/src/localpen/templates/starter/mdx-starter.ts
@@ -4,7 +4,7 @@ export const mdxStarter: Template = {
   name: 'mdx',
   title: 'MDX Starter',
   thumbnail: 'assets/templates/mdx.svg',
-  language: 'mdx',
+  activeEditor: 'markup',
   markup: {
     language: 'mdx',
     content: `

--- a/src/localpen/templates/starter/perl-starter.ts
+++ b/src/localpen/templates/starter/perl-starter.ts
@@ -4,7 +4,7 @@ export const perlStarter: Template = {
   name: 'perl',
   title: 'Perl Starter',
   thumbnail: 'assets/templates/perl.svg',
-  language: 'perl',
+  activeEditor: 'script',
   markup: {
     language: 'html',
     content: `

--- a/src/localpen/templates/starter/php-starter.ts
+++ b/src/localpen/templates/starter/php-starter.ts
@@ -4,7 +4,7 @@ export const phpStarter: Template = {
   name: 'php',
   title: 'PHP Starter',
   thumbnail: 'assets/templates/php.svg',
-  language: 'php',
+  activeEditor: 'script',
   markup: {
     language: 'html',
     content: `

--- a/src/localpen/templates/starter/polymer-starter.ts
+++ b/src/localpen/templates/starter/polymer-starter.ts
@@ -4,7 +4,7 @@ export const polymerStarter: Template = {
   name: 'polymer',
   title: 'Polymer Starter',
   thumbnail: 'assets/templates/polymer.svg',
-  language: 'typescript',
+  activeEditor: 'script',
   markup: {
     language: 'html',
     content: `

--- a/src/localpen/templates/starter/preact-starter.ts
+++ b/src/localpen/templates/starter/preact-starter.ts
@@ -4,7 +4,7 @@ export const preactStarter: Template = {
   name: 'preact',
   title: 'Preact Starter',
   thumbnail: 'assets/templates/preact.svg',
-  language: 'jsx',
+  activeEditor: 'script',
   markup: {
     language: 'html',
     content: '<div id="app"></div>\n',

--- a/src/localpen/templates/starter/python-starter.ts
+++ b/src/localpen/templates/starter/python-starter.ts
@@ -4,7 +4,7 @@ export const pythonStarter: Template = {
   name: 'python',
   title: 'Python Starter',
   thumbnail: 'assets/templates/python.svg',
-  language: 'python',
+  activeEditor: 'script',
   markup: {
     language: 'html',
     content: `

--- a/src/localpen/templates/starter/react-starter.ts
+++ b/src/localpen/templates/starter/react-starter.ts
@@ -4,7 +4,7 @@ export const reactStarter: Template = {
   name: 'react',
   title: 'React Starter',
   thumbnail: 'assets/templates/react.svg',
-  language: 'jsx',
+  activeEditor: 'script',
   markup: {
     language: 'html',
     content: '<div id="app">Loading...</div>\n',

--- a/src/localpen/templates/starter/readme-template.ts
+++ b/src/localpen/templates/starter/readme-template.ts
@@ -4,7 +4,7 @@ export const readmeTemplate: Template = {
   name: 'readme',
   title: 'README Template',
   thumbnail: 'assets/templates/markdown.svg',
-  language: 'markdown',
+  activeEditor: 'markup',
   markup: {
     language: 'markdown',
     content: `

--- a/src/localpen/templates/starter/ruby-starter.ts
+++ b/src/localpen/templates/starter/ruby-starter.ts
@@ -4,7 +4,7 @@ export const rubyStarter: Template = {
   name: 'ruby',
   title: 'Ruby Starter',
   thumbnail: 'assets/templates/ruby.svg',
-  language: 'ruby',
+  activeEditor: 'script',
   markup: {
     language: 'html',
     content: `

--- a/src/localpen/templates/starter/scheme-starter.ts
+++ b/src/localpen/templates/starter/scheme-starter.ts
@@ -4,7 +4,7 @@ export const schemeStarter: Template = {
   name: 'scheme',
   title: 'Scheme Starter',
   thumbnail: 'assets/templates/scheme.svg',
-  language: 'scheme',
+  activeEditor: 'script',
   markup: {
     language: 'html',
     content: `

--- a/src/localpen/templates/starter/stencil-starter.ts
+++ b/src/localpen/templates/starter/stencil-starter.ts
@@ -4,7 +4,7 @@ export const stencilStarter: Template = {
   name: 'stencil',
   title: 'Stencil Starter',
   thumbnail: 'assets/templates/stencil.png',
-  language: 'stencil',
+  activeEditor: 'script',
   markup: {
     language: 'html',
     content: '<my-app title="Stencil"></my-app>\n',

--- a/src/localpen/templates/starter/svelte-starter.ts
+++ b/src/localpen/templates/starter/svelte-starter.ts
@@ -4,7 +4,7 @@ export const svelteStarter: Template = {
   name: 'svelte',
   title: 'Svelte Starter',
   thumbnail: 'assets/templates/svelte.svg',
-  language: 'svelte',
+  activeEditor: 'script',
   markup: {
     language: 'html',
     content: '',

--- a/src/localpen/templates/starter/tailwindcss-starter.ts
+++ b/src/localpen/templates/starter/tailwindcss-starter.ts
@@ -4,7 +4,7 @@ export const tailwindcssStarter: Template = {
   name: 'tailwindcss',
   title: 'Tailwind CSS Starter',
   thumbnail: 'assets/templates/tailwindcss.svg',
-  language: 'html',
+  activeEditor: 'markup',
   markup: {
     language: 'html',
     content: `

--- a/src/localpen/templates/starter/typescript-starter.ts
+++ b/src/localpen/templates/starter/typescript-starter.ts
@@ -4,7 +4,7 @@ export const typescriptStarter: Template = {
   name: 'typescript',
   title: 'TypeScript Starter',
   thumbnail: 'assets/templates/typescript.svg',
-  language: 'typescript',
+  activeEditor: 'script',
   markup: {
     language: 'html',
     content: `

--- a/src/localpen/templates/starter/vue-sfc-starter.ts
+++ b/src/localpen/templates/starter/vue-sfc-starter.ts
@@ -4,7 +4,7 @@ export const vueSfcStarter: Template = {
   name: 'vue3',
   title: 'Vue 3 SFC Starter',
   thumbnail: 'assets/templates/vue.svg',
-  language: 'vue',
+  activeEditor: 'script',
   markup: {
     language: 'html',
     content: '',

--- a/src/localpen/templates/starter/vue-starter.ts
+++ b/src/localpen/templates/starter/vue-starter.ts
@@ -4,7 +4,7 @@ export const vueStarter: Template = {
   name: 'vue',
   title: 'Vue 2 Starter',
   thumbnail: 'assets/templates/vue.svg',
-  language: 'js',
+  activeEditor: 'script',
   markup: {
     language: 'html',
     content: `


### PR DESCRIPTION
this allows more consistent state (avoids setting a language that it not currently used in editors)

BREAKING CHANGE: use config option `activeEditor` instead of `language`
(automatically changed in config upgrade)